### PR TITLE
Changed Suit Names To Unicode

### DIFF
--- a/src/Suit.java
+++ b/src/Suit.java
@@ -1,8 +1,8 @@
 public enum Suit {
-    HEARTS("Hearts"),
-    SPADES("Spades"),
-    DIAMONDS("Diamonds"),
-    CLUBS("Clubs");
+    HEARTS("♥"),
+    SPADES("♠"),
+    DIAMONDS("♦"),
+    CLUBS("♣");
 
     private final String value;
 


### PR DESCRIPTION
I changed the "HEARTS, SPADES, DIAMONDS, and CLUBS to their Unicode versions, the names in the code should stay the same but when they are displayed in the game they should become ♥, ♠, ♦, and ♣.

They should be something like ♣King
